### PR TITLE
Fixed custom flags.

### DIFF
--- a/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/GlobalHandler.java
+++ b/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/GlobalHandler.java
@@ -70,9 +70,9 @@ public class GlobalHandler extends HandlerBase implements IGlobal {
         super(NAME, Integer.MIN_VALUE / 2);
         this.map = new CacheMap<>((key, map) -> Tristate.UNDEFINED);
         this.mapCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = map.get(FGUtil.nearestParent((Flag) o, map.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = map.get(FGUtil.nearestParent((IFlag) o, map.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });

--- a/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/GroupHandler.java
+++ b/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/GroupHandler.java
@@ -81,16 +81,16 @@ public class GroupHandler extends HandlerBase {
         this.defaultPermissions = defaultPermissions;
 
         this.groupPermCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = groupPermissions.get(FGUtil.nearestParent((Flag) o, groupPermissions.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = groupPermissions.get(FGUtil.nearestParent((IFlag) o, groupPermissions.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });
         this.defaultPermCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = defaultPermissions.get(FGUtil.nearestParent((Flag) o, defaultPermissions.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = defaultPermissions.get(FGUtil.nearestParent((IFlag) o, defaultPermissions.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });

--- a/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/PassiveHandler.java
+++ b/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/PassiveHandler.java
@@ -71,9 +71,9 @@ public class PassiveHandler extends HandlerBase {
         super(name, priority);
         this.map = map;
         this.mapCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = map.get(FGUtil.nearestParent((Flag) o, map.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = map.get(FGUtil.nearestParent((IFlag) o, map.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });

--- a/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/SimpleHandler.java
+++ b/src/main/java/net/foxdenstudio/sponge/foxguard/plugin/handler/SimpleHandler.java
@@ -97,23 +97,23 @@ public class SimpleHandler extends HandlerBase {
         this.defaultPermissions = defaultPermissions;
 
         this.ownerPermCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = ownerPermissions.get(FGUtil.nearestParent((Flag) o, ownerPermissions.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = ownerPermissions.get(FGUtil.nearestParent((IFlag) o, ownerPermissions.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });
         this.memberPermCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = memberPermissions.get(FGUtil.nearestParent((Flag) o, memberPermissions.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = memberPermissions.get(FGUtil.nearestParent((IFlag) o, memberPermissions.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });
         this.defaultPermCache = new CacheMap<>((o, m) -> {
-            if (o instanceof Flag) {
-                Tristate state = defaultPermissions.get(FGUtil.nearestParent((Flag) o, defaultPermissions.keySet()));
-                m.put((Flag) o, state);
+            if (o instanceof IFlag) {
+                Tristate state = defaultPermissions.get(FGUtil.nearestParent((IFlag) o, defaultPermissions.keySet()));
+                m.put((IFlag) o, state);
                 return state;
             } else return Tristate.UNDEFINED;
         });


### PR DESCRIPTION
Cache maps must check against IFlag to allow custom flags.

If this check is done against Flag, the returned tristate is always UNDEFINED.